### PR TITLE
Support windows

### DIFF
--- a/BetterCalibratorPopup/TargetManager.gd
+++ b/BetterCalibratorPopup/TargetManager.gd
@@ -37,7 +37,12 @@ func _process(_delta):
 var just_pressed = false
 
 func _on_gui_input(event):
-	if event is InputEventMouseButton:
+	if event is InputEventMouseButton && event.is_pressed() && event.get_button_index() == MOUSE_BUTTON_MIDDLE:
+		if DisplayServer.window_get_current_screen() == DisplayServer.get_screen_count() - 1:
+			DisplayServer.window_set_current_screen(0)
+		else:
+			DisplayServer.window_set_current_screen(DisplayServer.window_get_current_screen() + 1)
+	if event is InputEventMouseButton && event.get_button_index() != MOUSE_BUTTON_MIDDLE:
 		if not(just_pressed):
 			just_pressed = true
 			save_offset(targets[current_target], event.position)

--- a/BetterCalibratorPopup/export_presets.cfg
+++ b/BetterCalibratorPopup/export_presets.cfg
@@ -37,3 +37,69 @@ unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
 ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
 kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
 rm -rf \"{temp_dir}\""
+dotnet/include_scripts_content=false
+dotnet/include_debug_symbols=true
+
+[preset.1]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="./calibrator.x86_64.exe"
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+
+[preset.1.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=true
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=false
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"
+dotnet/include_scripts_content=false
+dotnet/include_debug_symbols=true

--- a/BetterCalibratorPopup/project.godot
+++ b/BetterCalibratorPopup/project.godot
@@ -20,6 +20,10 @@ config/icon="res://icon.svg"
 window/size/mode=4
 window/size/initial_position_type=3
 
+[dotnet]
+
+project/assembly_name="BetterCalibratorPopup"
+
 [editor_plugins]
 
 enabled=PackedStringArray()

--- a/release.sh
+++ b/release.sh
@@ -6,9 +6,10 @@ rm BetterCalibrator.zip
 mkdir tmp
 cd tmp
 
+godot --headless --path ../BetterCalibratorPopup --export-release "Windows Desktop" ../tmp/calibrator.exe
+godot --headless --path ../BetterCalibratorPopup --export-release "Linux/X11" ../tmp/calibrator.x86_64
+
 cp ../BetterCalibrator/bin/Release/net6.0/BetterCalibrator.dll .
-cp ../BetterCalibratorPopup/calibrator.x86_64 .
-cp ../BetterCalibratorPopup/calibrator.x86_64.exe .
 
 zip BetterCalibrator.zip BetterCalibrator.dll calibrator.x86_64 calibrator.x86_64.exe
 

--- a/release.sh
+++ b/release.sh
@@ -8,8 +8,9 @@ cd tmp
 
 cp ../BetterCalibrator/bin/Release/net6.0/BetterCalibrator.dll .
 cp ../BetterCalibratorPopup/calibrator.x86_64 .
+cp ../BetterCalibratorPopup/calibrator.x86_64.exe .
 
-zip BetterCalibrator.zip BetterCalibrator.dll calibrator.x86_64
+zip BetterCalibrator.zip BetterCalibrator.dll calibrator.x86_64 calibrator.x86_64.exe
 
 mv BetterCalibrator.zip ../
 


### PR DESCRIPTION
With godot it's rather simple to support windows and you should be able to compile both linux and windows releases from linux easily.

I haven't included the windows binary in this pr due to it generally being bad practice to put binaries in git repos. (If you want, I can add it in but really I'd recommend removing the linux one too)

I've also included a change that allows switching the monitor the program is on by pressing middle click. I'm not sure if this is only a windows issue but it doesn't seem to be possible to not launch it on the primary monitor otherwise.