### PR TITLE
Handle errors on file read

### DIFF
--- a/BetterCalibrator/BetterCalibrator.cs
+++ b/BetterCalibrator/BetterCalibrator.cs
@@ -97,7 +97,6 @@ public class BetterCalibrator : IPositionedPipelineElement<IDeviceReport> {
                 }
             } catch (Exception exception) {
                 Log.Exception(exception);
-                info = new OffsetInfo();
             }
             
         }

--- a/BetterCalibrator/BetterCalibrator.cs
+++ b/BetterCalibrator/BetterCalibrator.cs
@@ -90,9 +90,14 @@ public class BetterCalibrator : IPositionedPipelineElement<IDeviceReport> {
     private void try_resolve_output_mode() {
         if(!parsed) {
             parsed = true;
-            using(StreamReader reader = new StreamReader(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "/offsets.json")) {
-                string json = reader.ReadToEnd();
-                info = JsonSerializer.Deserialize<OffsetInfo>(json);
+            try {
+                using(StreamReader reader = new StreamReader(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "/offsets.json")) {
+                    string json = reader.ReadToEnd();
+                    info = JsonSerializer.Deserialize<OffsetInfo>(json);
+                }
+            } catch (Exception exception) {
+                Log.Exception(exception);
+                info = new OffsetInfo();
             }
             
         }


### PR DESCRIPTION
Currently, if a user enables the plugin without running the calibration program first it will error. This fixes that.

Related: https://github.com/OpenTabletDriver/OpenTabletDriver/issues/3203